### PR TITLE
Renamed the env var to DEVELOCITY_ACCESS_KEY

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Build with sbt
         run: sbt clean test
         env:
-          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.GE_SOLUTIONS_ACCESS_TOKEN }}


### PR DESCRIPTION
Renamed the env var to DEVELOCITY_ACCESS_KEY in build-verification.yml workflow as per the [documentation](https://docs.gradle.com/enterprise/sbt-plugin/#via_environment_variable).