### PR TITLE
Bump sbt 1.9.9 and fix local .m2 publishing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -85,6 +85,7 @@ credentials ++= {
     keyId <- sys.env.get("SIGN_KEY_ID")
   } yield Credentials("GnuPG Key ID", "gpg", keyId, "ignored")
 }
+publishM2Configuration := publishM2Configuration.value.withOverwrite(true) // allows overwriting local .m2 publishings
 
 addCommandAlias("publishSbtSnapshot", "; set publishTo := Some(\"SbtSnapshot\" at \"https://repo.grdev.net/artifactory/enterprise-libs-sbt-snapshots-local\") ; publish")
 addCommandAlias("publishSbtRc", "; set publishTo := Some(\"SbtReleaseCandidate\" at \"https://repo.grdev.net/artifactory/enterprise-libs-sbt-release-candidates-local\") ; publish")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.1
+sbt.version=1.9.9


### PR DESCRIPTION
- [Updated sbt to 1.9.9](https://github.com/gradle/common-custom-user-data-sbt-plugin/commit/5556d23eb608f279c7d9c9cba85fdfb141ff21d9)
- [Allowed overwriting local .m2 publishing even when not using SNAPSHOT versions](https://github.com/gradle/common-custom-user-data-sbt-plugin/commit/a5ef646ed70a8c1acdc8cae66ad2a3a5cdb40d8c) 