### PR TITLE
Fixed empty PR branch custom value

### DIFF
--- a/src/main/scala/com/gradle/internal/CustomBuildScanEnhancements.scala
+++ b/src/main/scala/com/gradle/internal/CustomBuildScanEnhancements.scala
@@ -199,7 +199,7 @@ class CustomBuildScanEnhancements(serverConfig: Server, scalaVersions: Seq[Strin
         ifDefined(buildUrl)(_.link("GitHub Actions build", _)),
         ifDefined(env.envVariable[String]("GITHUB_WORKFLOW"))(withCustomValueAndSearchLink(_, "CI workflow", _)),
         ifDefined(env.envVariable[String]("GITHUB_RUN_ID"))(withCustomValueAndSearchLink(_, "CI run", _)),
-        ifDefined(env.envVariable[String]("GITHUB_HEAD_REF"))(_.value("PR branch", _))
+        ifDefined(env.envVariable[String]("GITHUB_HEAD_REF").filter(_.nonEmpty))(_.value("PR branch", _))
       )
       Function.chain(ops)
     }


### PR DESCRIPTION
Fixes issue https://github.com/gradle/common-custom-user-data-sbt-plugin/issues/21.

Scans after the fix:
- with `export GITHUB_HEAD_REF=someBranch`: [scan](https://ge.solutions-team.gradle.com/s/dr7d4lo4xjnx2/custom-values#L6)
- with `export GITHUB_HEAD_REF= `: [scan](https://ge.solutions-team.gradle.com/s/yvvvk23q2vxhe/custom-values)