### PR TITLE
References to the Develocity Build Validation Scripts repository are renamed

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Visit our website to learn more about [Develocity][develocity].
 The sbt Develocity Common Custom User Data plugin is open-source software released under the [Apache 2.0 License][apache-license].
 
 [dv-build-config-samples]: https://github.com/gradle/develocity-build-config-samples
-[dv-build-validation-scripts]: https://github.com/gradle/gradle-enterprise-build-validation-scripts
+[dv-build-validation-scripts]: https://github.com/gradle/develocity-build-validation-scripts
 [dv-oss-projects]: https://github.com/gradle/develocity-oss-projects
 [ccud-gradle-plugin]: https://github.com/gradle/common-custom-user-data-gradle-plugin
 [ccud-maven-extension]: https://github.com/gradle/common-custom-user-data-maven-extension


### PR DESCRIPTION
> [!CAUTION]
> This PR is not to be merged until the renaming has taken place. This is currently scheduled to happen on Dec 17 during EMEA morning. Check https://github.com/gradle/develocity-build-validation-scripts to verify the current state.

This PR renames references to the old Develocity Build Validation Scripts repository name to https://github.com/gradle/develocity-build-validation-scripts