### PR TITLE
Added VS Code detection support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,9 @@ to/
 build/
 target/
 *.DS_Store
+# VS Code support
+.bloop/
+.metals/
+.vscode/
+.scala-build/
+**/metals.sbt

--- a/release/changes.md
+++ b/release/changes.md
@@ -1,0 +1,1 @@
+- [NEW] Added tagging VS Code builds

--- a/src/main/scala/com/gradle/internal/CustomBuildScanEnhancements.scala
+++ b/src/main/scala/com/gradle/internal/CustomBuildScanEnhancements.scala
@@ -56,6 +56,8 @@ private class CustomBuildScanEnhancements(serverConfig: Server, logger: Logger) 
   private val SYSTEM_PROP_IDEA_MANAGED = Env.Key[String]("idea.managed")
   private val SYSTEM_PROP_ECLIPSE_BUILD_ID = Env.Key[String]("eclipse.buildId")
   private val ENV_VARIABLE_IDEA_DIR = Env.Key[String]("IDEA_INITIAL_DIRECTORY")
+  private val ENV_VAR_VSCODE_PID = Env.Key[String]("VSCODE_PID")
+  private val ENV_VAR_VSCODE_INJECTION = Env.Key[String]("VSCODE_INJECTION")
 
   override def transform(originBuildScan: BuildScan)(implicit env: Env): BuildScan = {
     val ops = Seq(
@@ -86,6 +88,8 @@ private class CustomBuildScanEnhancements(serverConfig: Server, logger: Logger) 
           .orElse(env.sysProperty(SYSTEM_PROP_IDEA_MANAGED).map(_ => ("IntelliJ IDEA", None)))
           .orElse(env.envVariable(ENV_VARIABLE_IDEA_DIR).map(_ => ("IntelliJ IDEA", None)))
           .orElse(env.sysProperty(SYSTEM_PROP_ECLIPSE_BUILD_ID).map(v => ("Eclipse", Some(v))))
+          .orElse(env.envVariable(ENV_VAR_VSCODE_PID).map(_ => ("VS Code", None)))
+          .orElse(env.envVariable(ENV_VAR_VSCODE_INJECTION).map(_ => ("VS Code", None)))
           .getOrElse(("Cmd Line", None))
 
       val ops = Seq(


### PR DESCRIPTION
Added VS Code detection support.

From what I've gathered, there's no good direct support for running sbt builds in VS Code. You can either run them in the VS Code terminal or use the [Metals](https://scalameta.org/metals/docs/editors/vscode/) extension, which actually uses the [bloop](https://scalacenter.github.io/bloop/) build server (tool?) behind the scenes. However, it does use sbt with the `bloopInstall` task when importing the project. This integration handles both of these cases. From what I see, the `VSCODE_PID` env var is probably added with any extension build, so even if there are, or will come extensions that support running `sbt` tasks directly, this integration should handle those as well.

Here are some example scans with the `VS Code` tag:
- [bloopInstall](https://ge.solutions-team.gradle.com/s/ovekqcoy3ke2u)
- [compile](https://ge.solutions-team.gradle.com/s/zydf443pibcfi) - from VS Code terminal
- [loadp](https://ge.solutions-team.gradle.com/s/zvkg5oiheziu4) - triggered when changing build servers with Metals