### PR TITLE
Added a local selftest to the build-verification.yaml

### DIFF
--- a/.github/workflows/build-verification.yml
+++ b/.github/workflows/build-verification.yml
@@ -16,7 +16,62 @@ jobs:
           distribution: 'temurin'
       - name: Setup sbt installer
         uses: sbt/setup-sbt@v1.1.7
-      - name: Build with sbt
-        run: sbt clean test scripted
+      - name: Build and publish to M2 with sbt
+        run: sbt clean test scripted publishM2
+        env:
+          DEVELOCITY_ACCESS_KEY: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}
+      - name: Upload published plugin
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbt-develocity-common-custom-user-data
+          path: ~/.m2/repository/com/gradle
+
+  local-test:
+    name: Test with Locally Published Plugin
+    runs-on: ubuntu-latest
+    needs: verification
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'temurin'
+      - name: Setup sbt installer
+        uses: sbt/setup-sbt@v1.1.7
+      - name: Download plugin to maven local
+        uses: actions/download-artifact@v4
+        with:
+          name: sbt-develocity-common-custom-user-data
+          path: ~/.m2/repository/com/gradle
+      - name: Create a test project
+        run: |
+          mkdir -p ${{ runner.temp }}/ccud-sbt-integration-test/project
+          
+          echo """resolvers += Resolver.mavenLocal
+            addSbtPlugin(\"com.gradle\" % \"sbt-develocity\" % \"1+\")
+            addSbtPlugin(\"com.gradle\" % \"sbt-develocity-common-custom-user-data\" % \"1+\")
+          """ > ${{ runner.temp }}/ccud-sbt-integration-test/project/plugins.sbt
+          
+          echo """ThisBuild / scalaVersion := \"2.12.15\"
+            ThisBuild / organization := \"com.gradle\"
+            
+            ThisBuild / develocityConfiguration ~= { prev =>
+              prev
+                .withServer(
+                  prev.server.withUrl(Some(url(\"https://ge.solutions-team.gradle.com\")))
+                )
+                .withBuildScan(
+                  prev.buildScan
+                    .withObfuscation(prev.buildScan.obfuscation.withIpAddresses(_.map(_ => \"0.0.0.0\")))
+                    .withBackgroundUpload(!sys.env.contains(\"CI\"))
+                )
+              }
+          """ > ${{ runner.temp }}/ccud-sbt-integration-test/build.sbt
+      - name: Run a build with the locally published plugin
+        id: build-with-local-plugin
+        run: sbt clean
+        working-directory: ${{ runner.temp }}/ccud-sbt-integration-test
         env:
           DEVELOCITY_ACCESS_KEY: ${{ secrets.DV_SOLUTIONS_ACCESS_KEY }}


### PR DESCRIPTION
Added a local selftest to the build-verification.yaml, same logic as we have for CCUD Gradle - see [CCUD Gradle PR](https://github.com/gradle/common-custom-user-data-gradle-plugin/pull/410).

See the [build](https://github.com/gradle/common-custom-user-data-sbt-plugin/actions/runs/16222352590) with these changes.