### PR TITLE
Post 1.2 release activities

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Develocity plugin to be applied in your build to function.
 To activate the sbt Develocity Common Custom User Data plugin, add it to your project's `project/plugins.sbt` file, where you've already declared the main sbt Develocity plugin.
 
 ```
-addSbtPlugin("com.gradle" % "sbt-develocity-common-custom-user-data" % "1.1")
+addSbtPlugin("com.gradle" % "sbt-develocity-common-custom-user-data" % "1.2")
 ```
 
 For an example, see the [plugins.sbt](./project/plugins.sbt) file.
@@ -40,8 +40,9 @@ This table details the version compatibility of the sbt Develocity Common Custom
 
 | sbt Develocity Common Custom User Data plugin (this) versions | sbt Develocity plugin versions | sbt versions |
 |---------------------------------------------------------------|--------------------------------|--------------|
-| 1.0                                                           | 1.0                            | 1.6.0+       |
+| 1.2                                                           | 1.3                            | 1.9.0+       |
 | 1.1                                                           | 1.1.2                          | 1.6.0+       |
+| 1.0                                                           | 1.0                            | 1.6.0+       |
 
 ## Captured data
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("com.gradle" % "sbt-develocity" % "1.1.2")
+addSbtPlugin("com.gradle" % "sbt-develocity" % "1.3")
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.0")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.2.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")


### PR DESCRIPTION
- This plugin now requires sbt 1.9 (cannot be resolved by older versions)
- Upgrade to sbt-develocity 1.3