### PR TITLE
Add tag and custom value when sbt was invoked by AI Agents

### DIFF
--- a/src/main/scala/com/gradle/internal/CustomBuildScanEnhancements.scala
+++ b/src/main/scala/com/gradle/internal/CustomBuildScanEnhancements.scala
@@ -384,12 +384,12 @@ private class CustomBuildScanEnhancements(serverConfig: Server, logger: Logger) 
     val gemini = env.envVariable[String]("GEMINI_CLI")
 
     val ops = Seq(
-      ifDefined(claudeCode)((bs, _) => bs.withTag("AI Agent").withValue("AI Agent", "Claude Code")),
+      ifDefined(claudeCode)((bs, _) => bs.withTag("AI").withValue("AI agent", "Claude Code")),
       if (codexSandbox.isDefined || codexThreadId.isDefined)
-        (bs: BuildScan) => bs.withTag("AI Agent").withValue("AI Agent", "Codex")
+        (bs: BuildScan) => bs.withTag("AI").withValue("AI agent", "Codex")
       else identity[BuildScan] _,
-      ifDefined(openCode)((bs, _) => bs.withTag("AI Agent").withValue("AI Agent", "OpenCode")),
-      ifDefined(gemini)((bs, _) => bs.withTag("AI Agent").withValue("AI Agent", "Gemini CLI"))
+      ifDefined(openCode)((bs, _) => bs.withTag("AI").withValue("AI agent", "OpenCode")),
+      ifDefined(gemini)((bs, _) => bs.withTag("AI").withValue("AI agent", "Gemini CLI"))
     )
     Function.chain(ops)
   }

--- a/src/main/scala/com/gradle/internal/CustomBuildScanEnhancements.scala
+++ b/src/main/scala/com/gradle/internal/CustomBuildScanEnhancements.scala
@@ -65,7 +65,8 @@ private class CustomBuildScanEnhancements(serverConfig: Server, logger: Logger) 
       captureIde,
       captureCiOrLocal,
       captureCiMetadata,
-      captureGitMetadata
+      captureGitMetadata,
+      captureAgentMetadata
     )
     Function.chain(ops)(originBuildScan)
   }
@@ -371,6 +372,26 @@ private class CustomBuildScanEnhancements(serverConfig: Server, logger: Logger) 
       )
       Function.chain(ops)
     }
+  }
+
+  private def captureAgentMetadata(implicit env: Env): BuildScan => BuildScan = {
+    val claudeCode = env.envVariable[String]("CLAUDECODE")
+    // Codex environment variables are not officially documented.
+    // This is best effort detection until something more official is implemented by Codex.
+    val codexSandbox = env.envVariable[String]("CODEX_SANDBOX_NETWORK_DISABLED")
+    val codexThreadId = env.envVariable[String]("CODEX_THREAD_ID")
+    val openCode = env.envVariable[String]("OPENCODE")
+    val gemini = env.envVariable[String]("GEMINI_CLI")
+
+    val ops = Seq(
+      ifDefined(claudeCode)((bs, _) => bs.withTag("AI Agent").withValue("AI Agent", "Claude Code")),
+      if (codexSandbox.isDefined || codexThreadId.isDefined)
+        (bs: BuildScan) => bs.withTag("AI Agent").withValue("AI Agent", "Codex")
+      else identity[BuildScan] _,
+      ifDefined(openCode)((bs, _) => bs.withTag("AI Agent").withValue("AI Agent", "OpenCode")),
+      ifDefined(gemini)((bs, _) => bs.withTag("AI Agent").withValue("AI Agent", "Gemini CLI"))
+    )
+    Function.chain(ops)
   }
 
   private lazy val isGitInstalled: Boolean = {


### PR DESCRIPTION
## Summary
- Detect AI agent environment variables (Claude Code, Codex, OpenCode, Gemini CLI) and add an "AI" tag and "AI agent" custom value to build scans
- Ports the feature from [common-custom-user-data-gradle-plugin#465](https://github.com/gradle/common-custom-user-data-gradle-plugin/pull/465)