### PR TITLE
Exclude sbt 2.x from Renovate updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -19,6 +19,11 @@
       "allowedVersions": "~2.12"
     },
     {
+      // The plugin does not yet support sbt 2.x, so stay on the 1.x line.
+      "matchPackageNames": ["sbt/sbt"],
+      "allowedVersions": "<2.0.0"
+    },
+    {
       "matchPackageNames": ["com.gradle:sbt-develocity"],
       "matchFileNames": ["project/Dependencies.scala"],
       "enabled": false


### PR DESCRIPTION
The plugin does not yet support sbt 2.x. Renovate has started proposing the `1.x` → `2.0.0` bump for `sbt/sbt` (#109), which fails CI.

This pins `sbt/sbt` updates to the `1.x` line via `allowedVersions: "<2.0.0"`, mirroring the existing `scala-library` constraint, so Renovate stops opening 2.x PRs until the plugin adds support.