### PR TITLE
Capture Cursor as an AI agent

### DIFF
--- a/release/changes.md
+++ b/release/changes.md
@@ -1,0 +1,1 @@
+- [NEW] Capture Cursor as an AI agent via the `CURSOR_AGENT` environment variable

--- a/src/main/scala/com/gradle/internal/CustomBuildScanEnhancements.scala
+++ b/src/main/scala/com/gradle/internal/CustomBuildScanEnhancements.scala
@@ -382,6 +382,7 @@ private class CustomBuildScanEnhancements(serverConfig: Server, logger: Logger) 
     // This is best effort detection until something more official is implemented by Codex.
     val codexSandbox = env.envVariable[String]("CODEX_SANDBOX_NETWORK_DISABLED")
     val codexThreadId = env.envVariable[String]("CODEX_THREAD_ID")
+    val cursor = env.envVariable[String]("CURSOR_AGENT")
     val openCode = env.envVariable[String]("OPENCODE")
     val gemini = env.envVariable[String]("GEMINI_CLI")
 
@@ -390,6 +391,7 @@ private class CustomBuildScanEnhancements(serverConfig: Server, logger: Logger) 
       if (codexSandbox.isDefined || codexThreadId.isDefined)
         (bs: BuildScan) => bs.withTag("AI").withValue("AI agent", "Codex")
       else identity[BuildScan] _,
+      ifDefined(cursor)((bs, _) => bs.withTag("AI").withValue("AI agent", "Cursor")),
       ifDefined(openCode)((bs, _) => bs.withTag("AI").withValue("AI agent", "OpenCode")),
       ifDefined(gemini)((bs, _) => bs.withTag("AI").withValue("AI agent", "Gemini CLI"))
     )


### PR DESCRIPTION
Reimplements gradle/common-custom-user-data-gradle-plugin#517 for the sbt plugin. Cursor's CLI sets the `CURSOR_AGENT` environment variable when it runs shell commands, so its presence tags the build scan as an AI agent build with `AI agent` = `Cursor`.

The source PR also added Gemini in Android Studio detection via the `ANDROID_STUDIO_AGENT` environment variable. That part is intentionally not ported here, since Android Studio agent detection is Gradle only and the sbt plugin has no equivalent.

See the source PR for the full rationale and the references documenting `CURSOR_AGENT`.